### PR TITLE
Add chirpstack and mosquitto services

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="JavadocGenerationManager">
+    <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/javadoc" />
+  </component>
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/chirpstack/.gitkeep
+++ b/chirpstack/.gitkeep
@@ -1,0 +1,1 @@
+This is a placeholder file so the chirpstack directory (which would contain chirpstack config) would get added to git.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,65 @@ services:
       target: wqm101
     command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/wqm101.jar
     restart: unless-stopped
+
+  # Chirpstack containers
+  # Based on the official template docker-compose.yml at
+  # https://github.com/chirpstack/chirpstack-docker/blob/master/docker-compose.yml
+  chirpstack:
+    image: chirpstack/chirpstack:4
+    command: -c /etc/chirpstack
+    restart: unless-stopped
+    volumes:
+      - ./chirpstack/configuration/chirpstack:/etc/chirpstack
+      - ./chirpstack/lorawan-devices:/opt/lorawan-devices
+    depends_on:
+      - postgres
+      - mosquitto
+      - redis
+    environment:
+      - MQTT_BROKER_HOST=mosquitto
+      - REDIS_HOST=redis
+      - POSTGRESQL_HOST=postgres
+    ports:
+      - 8080:8080
+  chirpstack-gateway-bridge-eu868:
+    image: chirpstack/chirpstack-gateway-bridge:4
+    restart: unless-stopped
+    ports:
+      - 1700:1700/udp
+    volumes:
+      - ./chirpstack/configuration/chirpstack-gateway-bridge:/etc/chirpstack-gateway-bridge
+    depends_on:
+      - mosquitto
+  chirpstack-rest-api:
+    image: chirpstack/chirpstack-rest-api:4
+    restart: unless-stopped
+    command: --server chirpstack:8080 --bind 0.0.0.0:8090 --insecure
+    ports:
+      - 8090:8090
+    depends_on:
+      - chirpstack
+  postgres:
+    image: postgres:14-alpine
+    restart: unless-stopped
+    volumes:
+      - ./chirpstack/configuration/postgresql/initdb:/docker-entrypoint-initdb.d
+      - postgresqldata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=root
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+  mosquitto:
+    image: eclipse-mosquitto:2
+    restart: unless-stopped
+    ports:
+      - 1883:1883
+    volumes:
+      - ./chirpstack/configuration/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+
+volumes:
+  postgresqldata:
+  redisdata:


### PR DESCRIPTION
This will enable all of the following services to be deployed with just one `docker-compose` command:
- Chirpstack
- Mosquitto
- PostgreSQL
- Redis
- All taatta microservices