### PR TITLE
Add healthcheck and remove zipkin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ and [Docker Compose](https://docs.docker.com/compose/install/) installed.
 3. Review the Mosquitto and ChirpStack configuration at `configuration` directory
     - For example, you might want change the LoRa frequency for ChirpStack, or allow unauthenticated MQTT connections 
       for Mosquitto 
-4. Deploy the containers:
+4. Review `docker-compose.yml` and make any changes required for your setup
+5. Deploy the containers:
 
 ```shell
 docker compose up -d

--- a/athom-smart-plug/pom.xml
+++ b/athom-smart-plug/pom.xml
@@ -22,5 +22,10 @@
             <version>42.5.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/athom-smart-plug/src/main/resources/application-prod.yml
+++ b/athom-smart-plug/src/main/resources/application-prod.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback-prod.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/athom-smart-plug/src/main/resources/application-prod.yml
+++ b/athom-smart-plug/src/main/resources/application-prod.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: 'false'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback-prod.xml
 management:

--- a/athom-smart-plug/src/main/resources/application.yml
+++ b/athom-smart-plug/src/main/resources/application.yml
@@ -17,8 +17,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: 'true'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback.xml
 management:

--- a/athom-smart-plug/src/main/resources/application.yml
+++ b/athom-smart-plug/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 server:
   port: 4050
-
 spring:
   application:
     name: athom-smart-plug
@@ -22,3 +21,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/collector/src/main/kotlin/edu/monash/humanise/smartcity/collector/CollectorApplication.kt
+++ b/collector/src/main/kotlin/edu/monash/humanise/smartcity/collector/CollectorApplication.kt
@@ -71,7 +71,6 @@ class CollectorApplication {
                     *topics
             )
         }
-//        adapter.setCompletionTimeout(5000)
         adapter.setConverter(DefaultPahoMessageConverter())
         adapter.setQos(1)
         adapter.outputChannel = mqttInputChannel()

--- a/collector/src/main/resources/application-au915.yml
+++ b/collector/src/main/resources/application-au915.yml
@@ -1,15 +1,10 @@
 spring:
   application:
     name: collector
-  zipkin:
-    base-url: http://localhost:9411/
-
 server:
   port: 3030
-
 logging:
   config: classpath:logback-au915.xml
-
 smart-city:
   broker-url: tcp://${TAATTA_MOSQUITTO_HOST}:${TAATTA_MOSQUITTO_PORT}
   # authentication is optional -- default to null if not present

--- a/collector/src/main/resources/application-prod.yml
+++ b/collector/src/main/resources/application-prod.yml
@@ -1,19 +1,13 @@
 spring:
   application:
     name: collector
-  zipkin:
-    base-url: http://localhost:9411/
-
 server:
   port: 3030
-
 logging:
   config: classpath:logback-prod.xml
-
 smart-city:
   broker-url: tcp://${TAATTA_MOSQUITTO_HOST}:${TAATTA_MOSQUITTO_PORT}
   # authentication is optional -- default to null if not present
   # https://stackoverflow.com/questions/23348061/how-to-define-value-as-optional
   broker-username: ${TAATTA_MOSQUITTO_USER:#{null}}
   broker-password: ${TAATTA_MOSQUITTO_PASSWORD:#{null}}
-

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -1,20 +1,13 @@
 spring:
   application:
     name: collector
-  zipkin:
-    base-url: http://localhost:9411/
-
 server:
   port: 3030
-
 logging:
   config: classpath:logback.xml
-
 smart-city:
   broker-url: tcp://${TAATTA_MOSQUITTO_HOST}:${TAATTA_MOSQUITTO_PORT}
   # authentication is optional -- default to null if not present
   # https://stackoverflow.com/questions/23348061/how-to-define-value-as-optional
   broker-username: ${TAATTA_MOSQUITTO_USER:#{null}}
   broker-password: ${TAATTA_MOSQUITTO_PASSWORD:#{null}}
-
-

--- a/df702/pom.xml
+++ b/df702/pom.xml
@@ -25,5 +25,10 @@
             <version>42.5.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/df702/src/main/resources/application-prod.yml
+++ b/df702/src/main/resources/application-prod.yml
@@ -19,8 +19,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: 'false'
-  zipkin:
-    base-url: http://localhost:9411/
+
 
 logging:
   config: classpath:logback-prod.xml

--- a/df702/src/main/resources/application-prod.yml
+++ b/df702/src/main/resources/application-prod.yml
@@ -24,3 +24,9 @@ spring:
 
 logging:
   config: classpath:logback-prod.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/df702/src/main/resources/application.yml
+++ b/df702/src/main/resources/application.yml
@@ -19,8 +19,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: 'true'
-  zipkin:
-    base-url: http://localhost:9411/
+
 
 logging:
   config: classpath:logback.xml

--- a/df702/src/main/resources/application.yml
+++ b/df702/src/main/resources/application.yml
@@ -24,3 +24,9 @@ spring:
 
 logging:
   config: classpath:logback.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
       - TAATTA_MOSQUITTO_PASSWORD=${TAATTA_MOSQUITTO_PASSWORD}
       - TAATTA_SENSOR_ROUTERS=/taatta/collector/sensorRouters.json
     depends_on:
-      - mosquitto
+      mosquitto:
+        condition: service_started
+      athom-smart-plug:
+        condition: service_healthy
     restart: unless-stopped
     volumes:
       - ./configuration/collector/sensorRouters.json:/taatta/collector/sensorRouters.json:ro
@@ -62,6 +65,11 @@ services:
       postgresql:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: "curl --fail --silent localhost:4050/actuator/health | grep UP || exit 1"
+      interval: 5s
+      timeout: 5s
+      retries: 5
   # Chirpstack containers
   # Based on the official template docker-compose.yml at
   # https://github.com/chirpstack/chirpstack-docker/blob/v3/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,16 +13,23 @@ services:
     depends_on:
       mosquitto:
         condition: service_started
-      athom-smart-plug:
-        condition: service_healthy
+    # Uncomment the dependencies below depending on the services you're running, but don't uncomment those you don't use
+    # since docker will automatically run those services.
+    # This prevents flooding the collector logs with 'connection refused' errors while the logger module isn't ready yet.
+#      rhf1s001:
+#        condition: service_healthy
+#      pcr2:
+#        condition: service_healthy
+#      athom-smart-plug:
+#        condition: service_healthy
     restart: unless-stopped
     volumes:
       - ./configuration/collector/sensorRouters.json:/taatta/collector/sensorRouters.json:ro
-  rhs1s001:
+  rhf1s001:
     build:
       context: .
-      target: rhs1s001
-    command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/rhs1s001.jar
+      target: rhf1s001
+    command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/rhf1s001.jar
     ports:
       - 4040:4040
     environment:
@@ -33,6 +40,11 @@ services:
       postgresql:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: "curl --fail --silent localhost:4050/actuator/health | grep UP || exit 1"
+      interval: 5s
+      timeout: 5s
+      retries: 5
   pcr2:
     build:
       context: .
@@ -49,6 +61,11 @@ services:
       postgresql:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: "curl --fail --silent localhost:4050/actuator/health | grep UP || exit 1"
+      interval: 5s
+      timeout: 5s
+      retries: 5
   athom-smart-plug:
     build:
       context: .
@@ -135,7 +152,6 @@ services:
     restart: unless-stopped
     entrypoint: sh ./entrypoint.sh
     command: ["/usr/sbin/mosquitto","-c","/mosquitto/config/mosquitto.conf"]
-
 volumes:
   postgresqldata:
   redisdata:

--- a/ems701/src/main/resources/application-prod.yml
+++ b/ems701/src/main/resources/application-prod.yml
@@ -18,7 +18,6 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: 'false'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback-prod.xml

--- a/ems701/src/main/resources/application.yml
+++ b/ems701/src/main/resources/application.yml
@@ -18,7 +18,6 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: 'true'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback.xml

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -1,5 +1,3 @@
 spring:
   application:
     name: notification
-  zipkin:
-    base-url: http://localhost:9411/

--- a/pcr2/pom.xml
+++ b/pcr2/pom.xml
@@ -25,5 +25,10 @@
             <version>42.5.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pcr2/src/main/resources/application-prod.yml
+++ b/pcr2/src/main/resources/application-prod.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback-prod.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/pcr2/src/main/resources/application-prod.yml
+++ b/pcr2/src/main/resources/application-prod.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: 'false'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback-prod.xml
 management:

--- a/pcr2/src/main/resources/application.yml
+++ b/pcr2/src/main/resources/application.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/pcr2/src/main/resources/application.yml
+++ b/pcr2/src/main/resources/application.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: 'true'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback.xml
 management:

--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-sleuth-zipkin</artifactId>
-            <version>3.1.7</version>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>

--- a/rhf1s001/pom.xml
+++ b/rhf1s001/pom.xml
@@ -25,6 +25,11 @@
             <version>42.5.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rhf1s001/src/main/resources/application-prod.yml
+++ b/rhf1s001/src/main/resources/application-prod.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback-prod.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/rhf1s001/src/main/resources/application-prod.yml
+++ b/rhf1s001/src/main/resources/application-prod.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: 'false'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback-prod.xml
 management:

--- a/rhf1s001/src/main/resources/application.yml
+++ b/rhf1s001/src/main/resources/application.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/rhf1s001/src/main/resources/application.yml
+++ b/rhf1s001/src/main/resources/application.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: 'true'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback.xml
 management:

--- a/tbs220/pom.xml
+++ b/tbs220/pom.xml
@@ -24,6 +24,11 @@
             <version>42.5.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tbs220/src/main/resources/application-prod.yml
+++ b/tbs220/src/main/resources/application-prod.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback-prod.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/tbs220/src/main/resources/application-prod.yml
+++ b/tbs220/src/main/resources/application-prod.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: 'false'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback-prod.xml
 management:

--- a/tbs220/src/main/resources/application.yml
+++ b/tbs220/src/main/resources/application.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/tbs220/src/main/resources/application.yml
+++ b/tbs220/src/main/resources/application.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: 'true'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback.xml
 management:

--- a/wqm101/pom.xml
+++ b/wqm101/pom.xml
@@ -25,5 +25,10 @@
             <version>42.5.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/wqm101/src/main/resources/application-prod.yml
+++ b/wqm101/src/main/resources/application-prod.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback-prod.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/wqm101/src/main/resources/application-prod.yml
+++ b/wqm101/src/main/resources/application-prod.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: 'false'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback-prod.xml
 management:

--- a/wqm101/src/main/resources/application.yml
+++ b/wqm101/src/main/resources/application.yml
@@ -22,3 +22,9 @@ spring:
     base-url: http://localhost:9411/
 logging:
   config: classpath:logback.xml
+management:
+  endpoints:
+    enabled-by-default: false
+  endpoint:
+    health:
+      enabled: true

--- a/wqm101/src/main/resources/application.yml
+++ b/wqm101/src/main/resources/application.yml
@@ -18,8 +18,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: 'true'
-  zipkin:
-    base-url: http://localhost:9411/
+
 logging:
   config: classpath:logback.xml
 management:


### PR DESCRIPTION
- Add a healthcheck for each logger using [Spring Actuator](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html) so when using Docker Compose, the collector always starts after the logger modules, preventing a flood of `connection refused` errors in collector logs.
- Remove `org.springframework.cloud:spring-cloud-sleuth-zipkin` dependency because we don't seem to use it (no idea that's it even used for)