### PR TITLE
Push containers to container registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
             docs
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -46,6 +45,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: athom-presence-sensor
+            image: ${{ env.REGISTRY }}/athom-presence-sensor
+          - target: athom-smart-plug
+            image: ${{ env.REGISTRY }}/athom-smart-plug
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -63,11 +70,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ matrix.image }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.target }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -50,9 +51,9 @@ jobs:
       matrix:
         include:
           - target: athom-presence-sensor
-            image: ${{ env.REGISTRY }}/athom-presence-sensor
+            image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-athom-presence-sensor
           - target: athom-smart-plug
-            image: ${{ env.REGISTRY }}/athom-smart-plug
+            image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-athom-smart-plug
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,11 @@ jobs:
       matrix:
         include:
           - target: mosquitto
+            image: ghcr.io/taatta-mosquitto
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Sqt up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -65,7 +66,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/taatta-${{ matrix.target }}
+          images: ${{ matrix.image }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,17 @@ jobs:
       matrix:
         include:
           - target: athom-presence-sensor
-            image: ghcr.io/${{ github.repository }}-athom-presence-sensor
+            image: ghcr.io/taatta-athom-presence-sensor
           - target: athom-smart-plug
-            image: ghcr.io/${{ github.repository }}-athom-smart-plug
+            image: ghcr.io/taatta-athom-smart-plug
+          - target: collector
+            image: ghcr.io/taatta-collector
+          - target: mosquitto
+            image: ghcr.io/taatta-mosquitto
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Sqt up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
       - gh-actions
   pull_request:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -46,6 +43,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,35 +9,35 @@ on:
 
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: "17"
-          distribution: temurin
-          cache: maven
-      - name: Build
-        run: mvn -e clean package spring-boot:repackage
-      - name: Build documentation
-        run: mvn -e dokka:dokka dokka:javadoc
-      - name: Save files
-        uses: actions/upload-artifact@v3
-        with:
-          name: taatta
-          path: |
-            **/target/*.jar
-            **/target/dokka
-            **/target/dokkaJavadoc
-            .env.example
-            **/*.service
-            taatta.nginx
-            LICENSE
-            **/README.md
-            docs
+#  build:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v3
+#      - name: Set up JDK
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: "17"
+#          distribution: temurin
+#          cache: maven
+#      - name: Build
+#        run: mvn -e clean package spring-boot:repackage
+#      - name: Build documentation
+#        run: mvn -e dokka:dokka dokka:javadoc
+#      - name: Save files
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: taatta
+#          path: |
+#            **/target/*.jar
+#            **/target/dokka
+#            **/target/dokkaJavadoc
+#            .env.example
+#            **/*.service
+#            taatta.nginx
+#            LICENSE
+#            **/README.md
+#            docs
   docker:
     runs-on: ubuntu-latest
     permissions:
@@ -48,7 +48,6 @@ jobs:
       matrix:
         include:
           - target: mosquitto
-            image: ghcr.io/${{ github.repository }}-mosquitto
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -66,7 +65,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ matrix.image }}
+          images: ghcr.io/taatta-${{ matrix.target }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
       matrix:
         include:
           - target: athom-presence-sensor
-          - target: athom-smart-plug
-          - target: collector
-          - target: mosquitto
+#          - target: athom-smart-plug
+#          - target: collector
+#          - target: mosquitto
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches:
       - main
+      - gh-actions
   pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -36,4 +41,30 @@ jobs:
             LICENSE
             **/README.md
             docs
-
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Sqt up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
       matrix:
         include:
           - target: mosquitto
-            image: ghcr.io/taatta-mosquitto
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -66,7 +65,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ matrix.image }}
+          images: ghcr.io/${{ github.repository }}-${{ matrix.target }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ on:
       - gh-actions
   pull_request:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_BASE_NAME: taatta
-
 
 jobs:
   build:
@@ -51,14 +47,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: athom-presence-sensor
-#          - target: athom-smart-plug
-#          - target: collector
-#          - target: mosquitto
+          - target: mosquitto
+            image: ghcr.io/${{ github.repository }}-mosquitto
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Set up QEMU
+      - name: Sqt up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -72,7 +66,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}-${{ matrix.target }}
+          images: ${{ matrix.image }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - target: athom-presence-sensor
+          - target: athom-smart-plug
+          - target: collector
           - target: mosquitto
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,14 @@ jobs:
     permissions:
       contents: read
       packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: athom-presence-sensor
-            image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-athom-presence-sensor
+            image: ghcr.io/${{ github.repository }}-athom-presence-sensor
           - target: athom-smart-plug
-            image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-athom-smart-plug
+            image: ghcr.io/${{ github.repository }}-athom-smart-plug
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,35 +9,35 @@ on:
 
 
 jobs:
-#  build:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v3
-#      - name: Set up JDK
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: "17"
-#          distribution: temurin
-#          cache: maven
-#      - name: Build
-#        run: mvn -e clean package spring-boot:repackage
-#      - name: Build documentation
-#        run: mvn -e dokka:dokka dokka:javadoc
-#      - name: Save files
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: taatta
-#          path: |
-#            **/target/*.jar
-#            **/target/dokka
-#            **/target/dokkaJavadoc
-#            .env.example
-#            **/*.service
-#            taatta.nginx
-#            LICENSE
-#            **/README.md
-#            docs
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: temurin
+          cache: maven
+      - name: Build
+        run: mvn -e clean package spring-boot:repackage
+      - name: Build documentation
+        run: mvn -e dokka:dokka dokka:javadoc
+      - name: Save files
+        uses: actions/upload-artifact@v3
+        with:
+          name: taatta
+          path: |
+            **/target/*.jar
+            **/target/dokka
+            **/target/dokkaJavadoc
+            .env.example
+            **/*.service
+            taatta.nginx
+            LICENSE
+            **/README.md
+            docs
   docker:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - gh-actions
   pull_request:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE_NAME: taatta
+
 
 jobs:
   build:
@@ -48,13 +52,9 @@ jobs:
       matrix:
         include:
           - target: athom-presence-sensor
-            image: ghcr.io/taatta-athom-presence-sensor
           - target: athom-smart-plug
-            image: ghcr.io/taatta-athom-smart-plug
           - target: collector
-            image: ghcr.io/taatta-collector
           - target: mosquitto
-            image: ghcr.io/taatta-mosquitto
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}-${{ matrix.target }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mvn dependency:resolve
 
 COPY . .
 # reduce compile time by only building specific projects we need
-RUN mvn -e package spring-boot:repackage --project athom-presence-sensor athom-smart-plug collector
+RUN mvn --projects athom-presence-sensor,athom-smart-plug,collector -e package spring-boot:repackage
 
 FROM eclipse-temurin:17 AS base
 ENV TAATTA_DOCKER=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ ADD wqm101/pom.xml $HOME/wqm101/pom.xml
 RUN mvn dependency:resolve
 
 COPY . .
-RUN mvn -e package spring-boot:repackage
+# reduce compile time by only building specific projects we need
+RUN mvn -e package spring-boot:repackage --project athom-presence-sensor athom-smart-plug collector
 
 FROM eclipse-temurin:17 AS base
 ENV TAATTA_DOCKER=1
@@ -40,37 +41,37 @@ FROM base AS collector
 RUN ln -sf /dev/stdout /var/log/smart-city/collector.log
 COPY --from=builder /taatta/collector/target/collector-$VERSION.jar collector.jar
 
-FROM base AS df702
-RUN ln -sf /dev/stdout /var/log/smart-city/df702.log
-COPY --from=builder /taatta/df702/target/df702-$VERSION.jar df702.jar
-
-FROM base AS ems701
-RUN ln -sf /dev/stdout /var/log/smart-city/ems701.log
-COPY --from=builder /taatta/ems701/target/ems701-$VERSION.jar ems701.jar
-
-FROM base AS eureka-server
-RUN ln -sf /dev/stdout /var/log/smart-city/eureka-server.log
-COPY --from=builder /taatta/eureka-server/target/eureka-server-$VERSION.jar eureka-server.jar
-
-FROM base AS notification
-RUN ln -sf /dev/stdout /var/log/smart-city/notification.log
-COPY --from=builder /taatta/notification/target/notification-$VERSION.jar notification.jar
-
-FROM base AS pcr2
-RUN ln -sf /dev/stdout /var/log/smart-city/pcr2.log
-COPY --from=builder /taatta/pcr2/target/pcr2-$VERSION.jar pcr2.jar
-
-FROM base AS rhf1s001
-RUN ln -sf /dev/stdout /var/log/smart-city/rhf1s001.log
-COPY --from=builder /taatta/rhf1s001/target/rhf1s001-$VERSION.jar rhf1s001.jar
-
-FROM base AS tbs220
-RUN ln -sf /dev/stdout /var/log/smart-city/tbs220.log
-COPY --from=builder /taatta/tbs220/target/tbs220-$VERSION.jar tbs220.jar
-
-FROM base AS wqm101
-RUN ln -sf /dev/stdout /var/log/smart-city/wqm101.log
-COPY --from=builder /taatta/wqm101/target/wqm101-$VERSION.jar wqm101.jar
+#FROM base AS df702
+#RUN ln -sf /dev/stdout /var/log/smart-city/df702.log
+#COPY --from=builder /taatta/df702/target/df702-$VERSION.jar df702.jar
+#
+#FROM base AS ems701
+#RUN ln -sf /dev/stdout /var/log/smart-city/ems701.log
+#COPY --from=builder /taatta/ems701/target/ems701-$VERSION.jar ems701.jar
+#
+#FROM base AS eureka-server
+#RUN ln -sf /dev/stdout /var/log/smart-city/eureka-server.log
+#COPY --from=builder /taatta/eureka-server/target/eureka-server-$VERSION.jar eureka-server.jar
+#
+#FROM base AS notification
+#RUN ln -sf /dev/stdout /var/log/smart-city/notification.log
+#COPY --from=builder /taatta/notification/target/notification-$VERSION.jar notification.jar
+#
+#FROM base AS pcr2
+#RUN ln -sf /dev/stdout /var/log/smart-city/pcr2.log
+#COPY --from=builder /taatta/pcr2/target/pcr2-$VERSION.jar pcr2.jar
+#
+#FROM base AS rhf1s001
+#RUN ln -sf /dev/stdout /var/log/smart-city/rhf1s001.log
+#COPY --from=builder /taatta/rhf1s001/target/rhf1s001-$VERSION.jar rhf1s001.jar
+#
+#FROM base AS tbs220
+#RUN ln -sf /dev/stdout /var/log/smart-city/tbs220.log
+#COPY --from=builder /taatta/tbs220/target/tbs220-$VERSION.jar tbs220.jar
+#
+#FROM base AS wqm101
+#RUN ln -sf /dev/stdout /var/log/smart-city/wqm101.log
+#COPY --from=builder /taatta/wqm101/target/wqm101-$VERSION.jar wqm101.jar
 
 # mosquitto
 FROM eclipse-mosquitto:2 AS mosquitto

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   collector:
-    image: ghcr.io/taatta-collector
-    build:
-      context: .
-      target: collector
+    image: ghcr.io/monashsmartcitylivinglab/taatta-collector:gh-actions
+#    build:
+#      context: .
+#      target: collector
     command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/collector.jar
     environment:
       - TAATTA_MOSQUITTO_HOST=${TAATTA_MOSQUITTO_HOST}
@@ -18,10 +18,10 @@ services:
     volumes:
       - ./configuration/collector/sensorRouters.json:/taatta/collector/sensorRouters.json:ro
   athom-presence-sensor:
-    image: ghcr.io/taatta-athom-presence-sensor
-    build:
-      context: .
-      target: athom-presence-sensor
+    image: ghcr.io/monashsmartcitylivinglab/taatta-athom-presence-sensor:gh-actions
+#    build:
+#      context: .
+#      target: athom-presence-sensor
     command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/athom-presence-sensor.jar
     ports:
       - 4052:4052
@@ -40,10 +40,10 @@ services:
       timeout: 5s
       retries: 5
   athom-smart-plug:
-    image: ghcr.io/taatta-athom-smart-plug
-    build:
-      context: .
-      target: athom-smart-plug
+    image: ghcr.io/monashsmartcitylivinglab/taatta-athom-smart-plug:gh-actions
+#    build:
+#      context: .
+#      target: athom-smart-plug
     command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/athom-smart-plug.jar
     ports:
       - 4050:4050
@@ -113,10 +113,10 @@ services:
     volumes:
       - redisdata:/data
   mosquitto:
-    image: ghcr.io/taatta-mosquitto
-    build:
-      context: .
-      target: mosquitto
+    image: ghcr.io/monashsmartcitylivinglab/taatta-mosquitto:gh-actions
+#    build:
+#      context: .
+#      target: mosquitto
     ports:
       - 1883:1883
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   collector:
+    image: ghcr.io/taatta-collector
     build:
       context: .
       target: collector
@@ -13,60 +14,11 @@ services:
     depends_on:
       mosquitto:
         condition: service_started
-    # Uncomment the dependencies below depending on the services you're running, but don't uncomment those you don't use
-    # since docker will automatically run those services.
-    # This prevents flooding the collector logs with 'connection refused' errors while the logger module isn't ready yet.
-#      rhf1s001:
-#        condition: service_healthy
-#      pcr2:
-#        condition: service_healthy
-#      athom-smart-plug:
-#        condition: service_healthy
     restart: unless-stopped
     volumes:
       - ./configuration/collector/sensorRouters.json:/taatta/collector/sensorRouters.json:ro
-  rhf1s001:
-    build:
-      context: .
-      target: rhf1s001
-    command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/rhf1s001.jar
-    ports:
-      - 4040:4040
-    environment:
-      - TAATTA_POSTGRES_HOST=${TAATTA_POSTGRES_HOST}
-      - TAATTA_POSTGRES_PORT=${TAATTA_POSTGRES_PORT}
-      - TAATTA_POSTGRES_USER=${TAATTA_POSTGRES_USER}
-    depends_on:
-      postgresql:
-        condition: service_healthy
-    restart: unless-stopped
-    healthcheck:
-      test: "curl --fail --silent localhost:4050/actuator/health | grep UP || exit 1"
-      interval: 5s
-      timeout: 5s
-      retries: 5
-  pcr2:
-    build:
-      context: .
-      target: pcr2
-    command: java -jar -Dspring.profiles.active=prod /usr/local/taatta/pcr2.jar
-    ports:
-      - 4048:4048
-    environment:
-      - TAATTA_POSTGRES_HOST=${TAATTA_POSTGRES_HOST}
-      - TAATTA_POSTGRES_PORT=${TAATTA_POSTGRES_PORT}
-      - TAATTA_POSTGRES_USER=${TAATTA_POSTGRES_USER}
-      - TAATTA_POSTGRES_PASSWORD=${TAATTA_POSTGRES_PASSWORD}
-    depends_on:
-      postgresql:
-        condition: service_healthy
-    restart: unless-stopped
-    healthcheck:
-      test: "curl --fail --silent localhost:4050/actuator/health | grep UP || exit 1"
-      interval: 5s
-      timeout: 5s
-      retries: 5
   athom-presence-sensor:
+    image: ghcr.io/taatta-athom-presence-sensor
     build:
       context: .
       target: athom-presence-sensor
@@ -88,6 +40,7 @@ services:
       timeout: 5s
       retries: 5
   athom-smart-plug:
+    image: ghcr.io/taatta-athom-smart-plug
     build:
       context: .
       target: athom-smart-plug
@@ -160,6 +113,7 @@ services:
     volumes:
       - redisdata:/data
   mosquitto:
+    image: ghcr.io/taatta-mosquitto
     build:
       context: .
       target: mosquitto


### PR DESCRIPTION
One problem I found out when deploying the devices with pi 3 is that the containers are very slow to build, and sometimes it'd hang since it's running out of RAM. 

This PR will build the containers and push it to the [GitHub container registry](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images), thereby avoiding any compilation on the target machine itself.

Currently, the registry is private, so you'll need to log in on the docker commandline (see below). This might change in the future depending on how things go.

## How to test
1. Log in to the container registry by following [this guide](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
2. Run `docker compose up -d --force-recreate postgresql athom-smart-plug athom-presence-sensor mosquitto collector`
3. Check that all containers start properly

## Other notes

I've removed/commented out the lora stuff for now since they add more time to the build.